### PR TITLE
引数なしで実行した時に、選択可能なusertypeを事前に表示するように修正

### DIFF
--- a/survey.sh
+++ b/survey.sh
@@ -30,6 +30,8 @@ _ps_line() {
 case "${usertype}" in
   ('')
     _ps_msg "Input your usertype"
+    find . \( -path . -o -prune \) -type d -a -not -name ".*" |
+    sed -nE 's/^\.\//- /; p;' 1>&2
     _ps_line
     usertype="${line:?}"
     ;;
@@ -40,8 +42,6 @@ if
 then
   _ps_msg "error: Invalid usertype: ${usertype}"
   _ps_msg "Check valid usertype"
-  find . \( -path . -o -prune \) -type d -a -not -name ".*" |
-  sed -nE 's/^\.\//- /; p;' 1>&2
   exit 2
 else
   _prompt="${usertype:+(${usertype:-}) }survey"


### PR DESCRIPTION
引数なしで実行すると、以下のようにusertypeの入力を求められる。

```console
$ ./survey.sh
survey% Input your usertype
survey> 
```

このときに、beginnerとsupporterの2つを入力可能だが、スペルが難しくて間違えそうです。

先に選択可能なusertype一覧を表示するようにすると、便利だと思いました。

この修正後は、以下のようになります。

```console
$ ./survey.sh
survey% Input your usertype
- beginner
- supporter
survey> 
```